### PR TITLE
Use quote for addresses

### DIFF
--- a/static-configs/holesky/operator-docker-compose.yaml.example
+++ b/static-configs/holesky/operator-docker-compose.yaml.example
@@ -5,8 +5,8 @@ production: true
 
 # This is the address of the slasher which is deployed in the anvil saved state
 # The saved eigenlayer state is located in tests/anvil/eigenlayer-deployed-anvil-state.json
-avs_registry_coordinator_address: 0xE0315CCaF46A736BFAB173670CBcC97bE65Eb414
-operator_state_retriever_address: 0x12ddeDbB47340e6702529197cB593204A4aFa318
+avs_registry_coordinator_address: "0xE0315CCaF46A736BFAB173670CBcC97bE65Eb414"
+operator_state_retriever_address: "0x12ddeDbB47340e6702529197cB593204A4aFa318"
 
 # address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: https://us-central1-openoracle-de73b.cloudfunctions.net/backend_apis_holesky/api/report_result

--- a/static-configs/mainnet/operator-docker-compose.yaml
+++ b/static-configs/mainnet/operator-docker-compose.yaml
@@ -5,8 +5,8 @@ production: true
 
 # This is the address of the slasher which is deployed in the anvil saved state
 # The saved eigenlayer state is located in tests/anvil/eigenlayer-deployed-anvil-state.json
-avs_registry_coordinator_address: 0x7dd7320044013f7f49B1b6D67aED10726fe6e62b
-operator_state_retriever_address: 0x8b57BC00cF01841a78b09Fabe3C2D49A1303A060
+avs_registry_coordinator_address: "0x7dd7320044013f7f49B1b6D67aED10726fe6e62b"
+operator_state_retriever_address: "0x8b57BC00cF01841a78b09Fabe3C2D49A1303A060"
 
 # address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: https://us-central1-openoracle-de73b.cloudfunctions.net/backend_apis/api/report_result

--- a/static-configs/mainnet/operator-docker-compose.yaml.example
+++ b/static-configs/mainnet/operator-docker-compose.yaml.example
@@ -5,8 +5,8 @@ production: true
 
 # This is the address of the slasher which is deployed in the anvil saved state
 # The saved eigenlayer state is located in tests/anvil/eigenlayer-deployed-anvil-state.json
-avs_registry_coordinator_address: 0x7dd7320044013f7f49B1b6D67aED10726fe6e62b
-operator_state_retriever_address: 0x8b57BC00cF01841a78b09Fabe3C2D49A1303A060
+avs_registry_coordinator_address: "0x7dd7320044013f7f49B1b6D67aED10726fe6e62b"
+operator_state_retriever_address: "0x8b57BC00cF01841a78b09Fabe3C2D49A1303A060"
 
 # address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: https://us-central1-openoracle-de73b.cloudfunctions.net/backend_apis/api/report_result


### PR DESCRIPTION
We use Ansible (Python) to parse and update the configuration files during setup. Python interpreted the `0x...` values without quotes as hexadecimal numbers instead of strings. It will be great to use quotes to avoid this issue 🙏🏻 